### PR TITLE
Changed doctest to be cloned via https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external_libraries/doctest"]
 	path = external_libraries/doctest
-	url = git@github.com:doctest/doctest.git
+	url = https://github.com/doctest/doctest.git


### PR DESCRIPTION
This is useful when you simply want to clone the repo but don't intend to push changes to it.

Having the submodules over ssh made this more cumbersome (particularly on VM where you might not have your SSH keys at hand). This changes it so that submodules use https.